### PR TITLE
 fixing issue with DefineObjects not being strict when used in a PropertyDefinition

### DIFF
--- a/src/define.js
+++ b/src/define.js
@@ -795,8 +795,13 @@ makeDefinition = function(prop, def, defaultDefinition/*, typePrototype*/) {
 
 		// normalize type that implements can.new
 		if(value[newSymbol]) {
-			definition.type = value;
+			if(value[isMemberSymbol]) {
+				definition.type = value;
+			} else {
+				definition.type = type.check(value);
+			}
 		}
+
 		// normalize type that is a built-in constructor
 		else if (canReflect.isConstructorLike(value)) {
 			definition.type = type.check(value);

--- a/test/define-types-test.js
+++ b/test/define-types-test.js
@@ -279,6 +279,10 @@ QUnit.test("Can pass common/primitive types in a property definition", function(
 });
 
 QUnit.test("types throw when value is set to a different type", function(assert) {
+	function Thing() {}
+	Thing.prototype = Object.create(Thing);
+	class ExtendedDefineObject extends DefineObject {}
+
 	class Defined extends DefineObject {
 		static get define() {
 			return {
@@ -291,7 +295,15 @@ QUnit.test("types throw when value is set to a different type", function(assert)
 				numDefinition: { type: Number },
 				strDefinition: { type: String },
 				boolDefinition: { type: Boolean },
-				dateDefinition: { type: Date }
+				dateDefinition: { type: Date },
+				// custom type shorthand
+				thing: Thing,
+				defineObject: DefineObject,
+				extendedDefineObject: ExtendedDefineObject,
+				// custom type PropertyDefinition
+				thingDefinition: { type: Thing },
+				defineObjectDefinition: { type: DefineObject },
+				extendedDefineObjectDefinition: { type: ExtendedDefineObject }
 			};
 		}
 	}
@@ -306,7 +318,13 @@ QUnit.test("types throw when value is set to a different type", function(assert)
 		numDefinition: "33",
 		strDefinition: 33,
 		boolDefinition: "false",
-		dateDefinition: now.toString()
+		dateDefinition: now.toString(),
+		thing: {},
+		defineObject: {},
+		extendedDefineObject: {},
+		thingDefinition: {},
+		defineObjectDefinition: {},
+		extendedDefineObjectDefinition: {}
 	};
 
 	canReflect.eachKey(testCases, function(value, prop) {
@@ -314,7 +332,7 @@ QUnit.test("types throw when value is set to a different type", function(assert)
 			new Defined({
 				[prop]: value
 			});
-			assert.ok(false, "should throw but didn't");
+			assert.ok(false, `${prop} = ${value} should throw but didn't`);
 		} catch(err) {
 			assert.ok(true, "should throw: " + err);
 		}

--- a/test/define-types-test.js
+++ b/test/define-types-test.js
@@ -278,71 +278,45 @@ QUnit.test("Can pass common/primitive types in a property definition", function(
 	assert.strictEqual(thing.numPropWithDefault, 33, "{ type: Number, default: <number> } works");
 });
 
-QUnit.test("common/primitive types throw when used as the type option and set to a different type", function(assert) {
-	class MyNumberThing extends DefineObject {
+QUnit.test("types throw when value is set to a different type", function(assert) {
+	class Defined extends DefineObject {
 		static get define() {
 			return {
-				num: { type: Number }
-			};
-		}
-	}
-	class MyStringThing extends DefineObject {
-		static get define() {
-			return {
-				str: { type: String }
-			};
-		}
-	}
-	class MyBooleanThing extends DefineObject {
-		static get define() {
-			return {
-				bool: { type: Boolean }
-			};
-		}
-	}
-	class MyDateThing extends DefineObject {
-		static get define() {
-			return {
-				date: { type: Date }
+				// common primitive shorthand
+				num: Number,
+				str: String,
+				bool: Boolean,
+				date: Date,
+				// common primitive in PropertyDefinition
+				numDefinition: { type: Number },
+				strDefinition: { type: String },
+				boolDefinition: { type: Boolean },
+				dateDefinition: { type: Date }
 			};
 		}
 	}
 
 	let now = new Date();
 
-	try {
-		new MyNumberThing({
-			num: "33"
-		});
-		assert.ok(false, "should throw but didn't");
-	} catch(err) {
-		assert.ok(true, "should throw: " + err);
-	}
+	const testCases = {
+		num: "33",
+		str: 33,
+		bool: "false",
+		date: now.toString(),
+		numDefinition: "33",
+		strDefinition: 33,
+		boolDefinition: "false",
+		dateDefinition: now.toString()
+	};
 
-	try {
-		new MyStringThing({
-			str: 33
-		});
-		assert.ok(false, "should throw but didn't");
-	} catch(err) {
-		assert.ok(true, "should throw: " + err);
-	}
-
-	try {
-		new MyBooleanThing({
-			bool: "false"
-		});
-		assert.ok(false, "should throw but didn't");
-	} catch(err) {
-		assert.ok(true, "should throw: " + err);
-	}
-
-	try {
-		new MyDateThing({
-			date: now.toString()
-		});
-		assert.ok(false, "should throw but didn't");
-	} catch(err) {
-		assert.ok(true, "should throw: " + err);
-	}
+	canReflect.eachKey(testCases, function(value, prop) {
+		try {
+			new Defined({
+				[prop]: value
+			});
+			assert.ok(false, "should throw but didn't");
+		} catch(err) {
+			assert.ok(true, "should throw: " + err);
+		}
+	});
 });


### PR DESCRIPTION
closes https://github.com/canjs/can-define-mixin/issues/88.