### PR TITLE
Prevent reading __proto__

### DIFF
--- a/src/mixin-proxy.js
+++ b/src/mixin-proxy.js
@@ -13,12 +13,12 @@ let isProtoReadOnSuper = false;
 		let par = class { fn() { } };
 		let base = new Proxy(par, {
 			get(t, k, r) {
-				if(k === "__proto__") isProtoReadOnSuper = true;
+				if(k === "__proto__") { isProtoReadOnSuper = true; }
 				return Reflect.get(t, k, r);
 			}
-		})
+		});
 		let chi = class extends base { fn() { super.fn(); } };
-		(new chi).fn();
+		(new chi()).fn();
 	}
 })();
 
@@ -45,7 +45,7 @@ function proxyPrototype(Base) {
 				ObservationRecorder.add(receiver, key);
 			}
 			return Reflect.get(target, key, receiver);
-		}
+		};
 
 	const proxyHandlers = {
 		get: getHandler,

--- a/src/mixin-proxy.js
+++ b/src/mixin-proxy.js
@@ -4,6 +4,12 @@ const ObservationRecorder = require("can-observation-recorder");
 const eventDispatcher = defineBehavior.make.set.eventDispatcher;
 const inSetupSymbol = Symbol.for("can.initializing");
 
+// A bug in Safari means that __proto__ key is sent. This causes problems
+// When addEventListener is called on a non-element.
+// https://github.com/tc39/test262/pull/2203
+const ignoredKeys = new Set();
+ignoredKeys.add("__proto__");
+
 function proxyPrototype(Base) {
 	const instances = new WeakSet();
 
@@ -17,7 +23,7 @@ function proxyPrototype(Base) {
 
 	const proxyHandlers = {
 		get(target, key, receiver) {
-			if (!this[inSetupSymbol] && typeof key !== "symbol") {
+			if (!this[inSetupSymbol] && typeof key !== "symbol" && !ignoredKeys.has(key)) {
 				ObservationRecorder.add(receiver, key);
 			}
 			return Reflect.get(target, key, receiver);

--- a/test/define-mixin-proxy-object-test.js
+++ b/test/define-mixin-proxy-object-test.js
@@ -62,3 +62,22 @@ QUnit.test("Symbols are not observable", function(assert) {
 
 	assert.deepEqual(entries, [], "no observations are created");
 });
+
+QUnit.test("Does not observe __proto__", function(assert) {
+	class Parent extends DefineObject {
+		fn() {}
+	}
+	class Child extends Parent {
+		fn() {
+			super.fn();
+		}
+	}
+
+	let instance = new Child();
+
+	ObservationRecorder.start();
+	instance.fn();
+	let records = ObservationRecorder.stop();
+	let deps = Array.from(records.keyDependencies);
+	assert.equal(deps.length, 0, "Nothing recorded just by calling super.fn()");
+});


### PR DESCRIPTION
Safari has a bug where calling `super.fn()` sends a `__proto__` key read
through the proxy. Other browsers do not do this. But the implication is
that we will try to set up an event listener on `__proto__` on a
non-element which throws.

The tradeoff here is to either add a O(1) test for `__proto__` on every
read, or instead change can-reflect to use try/catch around
addEventListener. I am conflicted on which is the better solution. For
now I'm going with this.