### PR TITLE
async values that return a promise are initially undefined

### DIFF
--- a/src/define.js
+++ b/src/define.js
@@ -202,6 +202,7 @@ var callAsync = function(fn) {
 		// But that would be a breaking change so putting it here.
 		if(canReflect.isPromise(newValue)) {
 			newValue.then(resolve);
+			return undefined;
 		}
 
 		return newValue;

--- a/test/define-mixin-test.js
+++ b/test/define-mixin-test.js
@@ -62,8 +62,9 @@ QUnit.test("async(resolve) resolves async values", function(assert) {
 	}
 
 	let faves = new Faves();
+
 	canReflect.onKeyValue(faves, "age", value => {
-		assert.equal(value, 2, "Age incremented");
+		assert.equal(value, 2, "Age set when `resolve` is called");
 		done();
 	});
 });
@@ -88,8 +89,11 @@ QUnit.test("async() returning a promise resolves", function(assert) {
 	}
 
 	let faves = new Faves();
+
+	assert.equal(faves.age, undefined, "Age has correct initial value");
+
 	canReflect.onKeyValue(faves, "age", value => {
-		assert.equal(value, 2, "Age incremented");
+		assert.equal(value, 2, "Age set when promise resolves");
 		done();
 	});
 });


### PR DESCRIPTION
closes https://github.com/canjs/can-define-mixin/issues/98.