### PR TITLE
Add a warning for async behavior

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -47,6 +47,6 @@
 	"phantom": true,
 	"rhino": true,
 	"node": true,
-	"esnext": true,
-	"validthis": true
+	"validthis": true,
+	"esversion": 8
 }

--- a/test/define-mixin-test.js
+++ b/test/define-mixin-test.js
@@ -463,7 +463,7 @@ QUnit.test("Warn of async(resolve) is an async function", function(assert) {
 		static get define() {
 			return  {
 				todos: {
-					async async(resolve) {
+					async async(resolve) { // jshint ignore:line
 
 					}
 				}

--- a/test/define-mixin-test.js
+++ b/test/define-mixin-test.js
@@ -457,3 +457,21 @@ QUnit.test("Error for required properties includes the function name", function(
 		}
 
 });
+
+QUnit.test("Warn of async(resolve) is an async function", function(assert) {
+	class MyThing extends mixinObject() {
+		static get define() {
+			return  {
+				todos: {
+					async async(resolve) {
+
+					}
+				}
+			};
+		}
+	}
+
+	let count = dev.willWarn(/async function/);
+	new MyThing();
+	assert.equal(count(), 1, "1 warning");
+});


### PR DESCRIPTION
Adds a warning for async behaviors that use both an async function and
the resolve() argument.