### PR TITLE
adding support for type:Function and functions as defaults

### DIFF
--- a/test/define-mixin-default-test.js
+++ b/test/define-mixin-default-test.js
@@ -110,3 +110,59 @@ QUnit.test("Allow a default object to be provided by using a getter", function(a
 	assert.deepEqual(one.prop, { foo: "bar" }, "Sets the default");
 	assert.notEqual(one.prop, two.prop, "Different instances");
 });
+
+QUnit.test("Functions can be provided as the default in the PropDefinition", function(assert) {
+	assert.expect(3);
+
+	class Person extends DefineObject {
+		static get define() {
+			return {
+				getAge: {
+					default() {
+						return 13;
+					}
+				}
+			};
+		}
+	}
+
+	let person = new Person();
+
+	assert.equal(person.getAge(), 13, "property is a function");
+
+	person.getAge = function() { return 30; };
+	assert.equal(person.getAge(), 30, "function can be overwritten");
+
+	try {
+		person.getAge = 50;
+	} catch(e) {
+		assert.ok(true, "setting property to a non-function throws an error");
+	}
+});
+
+QUnit.test("Functions can be provided as the default as the property value", function(assert) {
+	assert.expect(3);
+
+	class Person extends DefineObject {
+		static get define() {
+			return {
+				getAge() {
+					return 13;
+				}
+			};
+		}
+	}
+
+	let person = new Person();
+
+	assert.equal(person.getAge(), 13, "property is a function");
+
+	person.getAge = function() { return 30; };
+	assert.equal(person.getAge(), 30, "function can be overwritten");
+
+	try {
+		person.getAge = 50;
+	} catch(e) {
+		assert.ok(true, "setting property to a non-function throws an error");
+	}
+});

--- a/test/define-types-test.js
+++ b/test/define-types-test.js
@@ -338,3 +338,79 @@ QUnit.test("types throw when value is set to a different type", function(assert)
 		}
 	});
 });
+
+QUnit.test("Can pass Function as the type option", function(assert) {
+	assert.expect(3);
+
+	class MyThing extends DefineObject {
+		static get define() {
+			return {
+				func: Function
+			};
+		}
+	}
+
+	let thing = new MyThing({
+		func: function() { return 33; }
+	});
+
+	assert.equal(thing.func(), 33, "function accepted");
+
+	thing.func = function() { return 30; };
+	assert.equal(thing.func(), 30, "function can be overwritten");
+
+	try {
+		thing.func = 50;
+	} catch(e) {
+		assert.ok(true, "error thrown when set to non-function");
+	}
+});
+
+QUnit.test("Can pass Function in a property definition", function(assert) {
+	assert.expect(9);
+
+	class MyThing extends DefineObject {
+		static get define() {
+			return {
+				func: Function,
+				funcProp: { type: Function },
+				funcPropWithDefault: { type: Function, default() { return 33; } }
+			};
+		}
+	}
+
+	let thing = new MyThing({
+		func: function() { return 33; },
+		funcProp: function() { return 33; }
+	});
+
+	assert.strictEqual(thing.func(), 33, "prop: Function works");
+	assert.strictEqual(thing.funcProp(), 33, "{ type: Function } works");
+	assert.strictEqual(thing.funcPropWithDefault(), 33, "{ type: Function, default: <Function> } works");
+
+	thing.func = function() { return 30; };
+	thing.funcProp = function() { return 30; };
+	thing.funcPropWithDefault = function() { return 30; };
+
+	assert.strictEqual(thing.func(), 30, "prop: Function can be overwritten");
+	assert.strictEqual(thing.funcProp(), 30, "{ type: Function } can be overwritten");
+	assert.strictEqual(thing.funcPropWithDefault(), 30, "{ type: Function, default: <Function> } can be overwritten");
+
+	try {
+		thing.func = 50;
+	} catch(e) {
+		assert.ok(true, "prop: Function error thrown when set to non-function");
+	}
+
+	try {
+		thing.funcProp = 50;
+	} catch(e) {
+		assert.ok(true, "{ type: Function } error thrown when set to non-function");
+	}
+
+	try {
+		thing.funcPropWithDefault = 50;
+	} catch(e) {
+		assert.ok(true, "{ type: Function, default: <Function> } error thrown when set to non-function");
+	}
+});


### PR DESCRIPTION
closes https://github.com/canjs/can-define-mixin/issues/87.
closes https://github.com/canjs/can-define-mixin/issues/96.