### PR TITLE
107 warn ignored type

### DIFF
--- a/src/define.js
+++ b/src/define.js
@@ -238,6 +238,22 @@ define.property = function(typePrototype, prop, definition, dataInitializers, co
 
 	var type = definition.type;
 
+	//!steal-remove-start
+	if(process.env.NODE_ENV !== 'production') {
+		if(!definition.set && definition.get && definition.get.length === 0 && ( "default" in definition ) ) {
+			canLogDev.warn("can-define-object: default value for property " +
+					canReflect.getName(typePrototype)+"."+ prop +
+					" ignored, as its definition has a zero-argument getter and no setter");
+		}
+
+	if(!definition.set && definition.get && definition.get.length === 0 && ( definition.type ) ) {
+			canLogDev.warn("can-define-object: type value for property " +
+					canReflect.getName(typePrototype)+"."+ prop +
+					" ignored, as its definition has a zero-argument getter and no setter");
+		}
+	}
+	//!steal-remove-start
+
 	// Special case definitions that have only `type: "*"`.
 	if (type && onlyType(definition) && type === type.Any) {
 		Object_defineNamedPrototypeProperty(typePrototype, prop, {

--- a/src/define.js
+++ b/src/define.js
@@ -246,7 +246,7 @@ define.property = function(typePrototype, prop, definition, dataInitializers, co
 					" ignored, as its definition has a zero-argument getter and no setter");
 		}
 
-	if(!definition.set && definition.get && definition.get.length === 0 && ( definition.type ) ) {
+	if(!definition.set && definition.get && definition.get.length === 0 && ( definition.type && definition.type !== defaultDefinition.type ) ) {
 			canLogDev.warn("can-define-object: type value for property " +
 					canReflect.getName(typePrototype)+"."+ prop +
 					" ignored, as its definition has a zero-argument getter and no setter");

--- a/test/define-mixin-test.js
+++ b/test/define-mixin-test.js
@@ -483,7 +483,7 @@ dev.devOnlyTest("warnings are given when type or default is ignored", function(a
 			definition: {
 				get() { return "whatever"; }
 			},
-			warning: /type .* ignored/,
+			warning: /Set value for property .* ignored/,
 			setProp: true,
 			expectedWarnings: 1
 		},
@@ -493,7 +493,7 @@ dev.devOnlyTest("warnings are given when type or default is ignored", function(a
 				type: String,
 				get() { return "whatever"; }
 			},
-			warning: /type .* ignored/,
+			warning: /type value for property .* ignored/,
 			setProp: false,
 			expectedWarnings: 1
 		},
@@ -506,12 +506,14 @@ dev.devOnlyTest("warnings are given when type or default is ignored", function(a
 			setProp: false,
 			expectedWarnings: 0
 		},
+		{
+			name: "type with zero-arg getter, with setter should not warn",
 			definition: {
 				type: String,
 				get() { return "whatever"; },
 				set (val) { return val; }
 			},
-			warning: /type .* ignored/,
+			warning: /type value for property .* ignored/,
 			setProp: false,
 			expectedWarnings: 0
 		},
@@ -521,18 +523,18 @@ dev.devOnlyTest("warnings are given when type or default is ignored", function(a
 				default: "some thing",
 				get() { return "whatever"; }
 			},
-			warning: /default .* ignored/,
+			warning: /default value for property .* ignored/,
 			setProp: false,
 			expectedWarnings: 1
 		},
 		{
-			name: "default with zero-arg getter, with setter",
+			name: "default with zero-arg getter, with setter should not warn",
 			definition: {
 				default: "some thing",
 				get() { return "whatever"; },
 				set (val) { return val; }
 			},
-			warning: /type .* ignored/,
+			warning: /default value for property .* ignored/,
 			setProp: false,
 			expectedWarnings: 0
 		}

--- a/test/define-mixin-test.js
+++ b/test/define-mixin-test.js
@@ -258,9 +258,9 @@ QUnit.test("Passing props into the constructor", function(assert) {
 
 QUnit.test("seal: false prevents the object from being sealed", function(assert) {
 	class Thing extends mixinObject() {
-	  static get seal() {
-		  return false;
-	  }
+		static get seal() {
+			return false;
+		}
 	}
 
 	let p = new Thing();
@@ -473,5 +473,28 @@ QUnit.test("Warn of async(resolve) is an async function", function(assert) {
 
 	let count = dev.willWarn(/async function/);
 	new MyThing();
+	assert.equal(count(), 1, "1 warning");
+});
+
+
+QUnit.test("If there's zero-arg `get` but not `set`, warn on all sets in dev mode", function(assert) {
+	class MyThing extends mixinObject() {
+		static get define() {
+			return  {
+				todos: {
+					get () { // jshint ignore:line
+						return 'no args here, and no setter!'
+					}
+				}
+			};
+		}
+	}
+
+	let count = dev.willWarn(/Set value for property .* has a zero-argument getter and no setter/);
+	new MyThing();
+	// trigger the warning
+	const myThing = new MyThing();
+	myThing.todos = 'something'
+
 	assert.equal(count(), 1, "1 warning");
 });

--- a/test/define-mixin-test.js
+++ b/test/define-mixin-test.js
@@ -502,7 +502,7 @@ dev.devOnlyTest("warnings are given when type or default is ignored", function(a
 			definition: {
 				type: String,
 				get() { return "whatever"; },
-				set (val) { return val }
+				set (val) { return val; }
 			},
 			warning: /type .* ignored/,
 			setProp: false,
@@ -523,7 +523,7 @@ dev.devOnlyTest("warnings are given when type or default is ignored", function(a
 			definition: {
 				default: "some thing",
 				get() { return "whatever"; },
-				set (val) { return val }
+				set (val) { return val; }
 			},
 			warning: /type .* ignored/,
 			setProp: false,
@@ -547,6 +547,6 @@ dev.devOnlyTest("warnings are given when type or default is ignored", function(a
 			o.prop = "a value";
 		}
 
-		assert.equal(count(), testCase.expectedWarnings, `got correct number of warnings for "${testCase.name}"`)
+		assert.equal(count(), testCase.expectedWarnings, `got correct number of warnings for "${testCase.name}"`);
 	});
 });

--- a/test/define-mixin-test.js
+++ b/test/define-mixin-test.js
@@ -498,7 +498,14 @@ dev.devOnlyTest("warnings are given when type or default is ignored", function(a
 			expectedWarnings: 1
 		},
 		{
-			name: "type with zero-arg getter, with setter",
+			name: "type with zero-arg getter, no setter, only default type should not warn",
+			definition: {
+				get() { return "whatever"; }
+			},
+			warning: /type value for property .* ignored/,
+			setProp: false,
+			expectedWarnings: 0
+		},
 			definition: {
 				type: String,
 				get() { return "whatever"; },

--- a/test/define-mixin-test.js
+++ b/test/define-mixin-test.js
@@ -498,7 +498,7 @@ dev.devOnlyTest("warnings are given when type or default is ignored", function(a
 			expectedWarnings: 1
 		},
 		{
-			name: "type with zero-arg getter, no setter, only default type should not warn",
+			name: "only default type with zero-arg getter, no setter - should not warn",
 			definition: {
 				get() { return "whatever"; }
 			},
@@ -507,7 +507,7 @@ dev.devOnlyTest("warnings are given when type or default is ignored", function(a
 			expectedWarnings: 0
 		},
 		{
-			name: "type with zero-arg getter, with setter should not warn",
+			name: "type with zero-arg getter, with setter - should not warn",
 			definition: {
 				type: String,
 				get() { return "whatever"; },
@@ -528,7 +528,7 @@ dev.devOnlyTest("warnings are given when type or default is ignored", function(a
 			expectedWarnings: 1
 		},
 		{
-			name: "default with zero-arg getter, with setter should not warn",
+			name: "default with zero-arg getter, with setter - should not warn",
 			definition: {
 				default: "some thing",
 				get() { return "whatever"; },

--- a/test/define-test.js
+++ b/test/define-test.js
@@ -9,9 +9,9 @@ QUnit.test("Can define stuff", function(assert) {
   class Faves extends mixinObject() {
     static get define() {
       return {
-		  color: {
-			  default: "blue"
-		  }
+			color: {
+				default: "blue"
+			}
       };
     }
   }
@@ -30,9 +30,9 @@ QUnit.test("Stuff is defined in constructor for non-element classes", function(a
   class Faves extends mixinObject(Object) {
     static get define() {
       return {
-		  color: {
-			  default: "blue"
-		  }
+			color: {
+				default: "blue"
+			}
       };
     }
 


### PR DESCRIPTION
This adds dev-only warnings for `define-mixin` objects with:
- zero-arg getter, with setter on each `set` call
- zero-arg getter, with type, no setter during setup
- zero-arg getter, with default, no setter during setup

This also tests that warnings do no happen for: 
- zero-arg getter, with type, _with setter_ during setup
- zero-arg getter, with default, _with setter_ during setup

Closes #107 