### PR TITLE
Implement deleteKeyValue

### DIFF
--- a/src/define-helpers.js
+++ b/src/define-helpers.js
@@ -85,6 +85,7 @@ const defineHelpers = {
 		var instanceDefines = this._instanceDefinitions;
 		if(instanceDefines && Object.prototype.hasOwnProperty.call(instanceDefines, prop) && !Object.isSealed(this)) {
 			delete instanceDefines[prop];
+			delete this[prop];
 			queues.batch.start();
 			this.dispatch({
 				type: "can.keys",

--- a/src/mixin-mapprops.js
+++ b/src/mixin-mapprops.js
@@ -160,6 +160,10 @@ module.exports = function(Type) {
 			return getKeyValue.apply(this, args);
 		}
 
+		[Symbol.for("can.deleteKeyValue")](...args) {
+			return defineHelpers.deleteKey.call(this, ...args);
+		}
+
 		[Symbol.for("can.getOwnEnumerableKeys")]() {
 			ObservationRecorder.add(this, 'can.keys');
 			ObservationRecorder.add(Object.getPrototypeOf(this), 'can.keys');

--- a/test/define-mixin-test.js
+++ b/test/define-mixin-test.js
@@ -576,6 +576,7 @@ QUnit.test("Properties can be deleted", function(assert) {
 
 	obj.deleteKey("bar");
 	assert.equal(obj.bar, undefined, "no longer exists");
+	assert.equal(Object.keys(obj).length, 2, "2 props now");
 	obj.bar = "test";
 	assert.equal(obj.bar, "test", "can add back");
 });

--- a/test/define-mixin-test.js
+++ b/test/define-mixin-test.js
@@ -559,3 +559,23 @@ dev.devOnlyTest("warnings are given when type or default is ignored", function(a
 		assert.equal(count(), testCase.expectedWarnings, `got correct number of warnings for "${testCase.name}"`);
 	});
 });
+
+QUnit.test("Properties can be deleted", function(assert) {
+	const MyObject = class extends mixinObject() {};
+
+	let obj = new MyObject({
+		foo: "foo",
+		bar: "bar",
+		qux: "qux"
+	});
+
+	canReflect.deleteKeyValue(obj, "foo");
+	assert.equal(obj.foo, undefined, "no longer exists");
+	obj.foo = "test";
+	assert.equal(obj.foo, "test", "can add back");
+
+	obj.deleteKey("bar");
+	assert.equal(obj.bar, undefined, "no longer exists");
+	obj.bar = "test";
+	assert.equal(obj.bar, "test", "can add back");
+});


### PR DESCRIPTION
Making `delete foo.bar` work is more difficult and this doesn't cover
that. The reason is that properties are defined lower in the prototype
chain, so the `deleteProperty` trap is not caught.